### PR TITLE
Remove "Backend" from string

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:label="@string/app_name">
         <service
             android:name=".BackendService"
-            android:label="Nominatim Backend">
+            android:label="Nominatim">
             <intent-filter>
                 <action android:name="org.microg.nlp.GEOCODER_BACKEND"/>
             </intent-filter>


### PR DESCRIPTION
Avoid needless repetition: This is displayed in a menu where it already says in the title bar that backends are configured.
