### PR TITLE
Issue4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ repositories {
 
 dependencies {
     compile 'org.microg:unifiednlp-api:1.3.2'
+    compile 'com.android.support:appcompat-v7:22.2.1'
 }
 
 android {

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ repositories {
 
 dependencies {
     compile 'org.microg:unifiednlp-api:1.3.2'
-    compile 'com.android.support:appcompat-v7:22.2.1'
 }
 
 android {

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.microg.nlp.backend.nominatim"
+    android:versionName="1.1.1"
     android:versionCode="10101"
-    android:versionName="1.1.1">
+    package="org.microg.nlp.backend.nominatim">
+
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <uses-sdk
         android:minSdkVersion="11"
         android:targetSdkVersion="22" />
-
-    <uses-permission android:name="android.permission.INTERNET" />
-
-    <android:uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <android:uses-permission android:name="android.permission.READ_PHONE_STATE" />
-    <android:uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="false"

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          android:versionName="1.1.1"
-          android:versionCode="10101"
-          package="org.microg.nlp.backend.nominatim">
-
-    <uses-permission android:name="android.permission.INTERNET"/>
+    package="org.microg.nlp.backend.nominatim"
+    android:versionCode="10101"
+    android:versionName="1.1.1">
 
     <uses-sdk
-        android:minSdkVersion="9"
-        android:targetSdkVersion="22"/>
+        android:minSdkVersion="11"
+        android:targetSdkVersion="22" />
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <android:uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <android:uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <android:uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
     <application
         android:allowBackup="false"
         android:icon="@drawable/ic_launcher"
@@ -17,8 +22,18 @@
             android:name=".BackendService"
             android:label="@string/backend_name">
             <intent-filter>
-                <action android:name="org.microg.nlp.GEOCODER_BACKEND"/>
+                <action android:name="org.microg.nlp.GEOCODER_BACKEND" />
             </intent-filter>
+            <meta-data
+                android:name="org.microg.nlp.BACKEND_SETTINGS_ACTIVITY"
+                android:value="org.microg.nlp.backend.nominatim.SettingsActivity" />
         </service>
+
+        <activity android:name=".SettingsActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+            </intent-filter>
+        </activity>
     </application>
+
 </manifest>

--- a/src/main/java/org/microg/nlp/backend/nominatim/BackendService.java
+++ b/src/main/java/org/microg/nlp/backend/nominatim/BackendService.java
@@ -1,10 +1,12 @@
 package org.microg.nlp.backend.nominatim;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.location.Address;
 import android.net.Uri;
 import android.os.Build;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
 import org.json.JSONArray;
@@ -28,11 +30,11 @@ public class BackendService extends GeocoderBackendService {
     private static final String SERVICE_URL_MAPQUEST = "http://open.mapquestapi.com/nominatim/v1/";
     private static final String SERVICE_URL_OSM = " http://nominatim.openstreetmap.org/";
     private static final String REVERSE_GEOCODE_URL =
-            "%sreverse?format=json&accept-language=%s&lat=%f&lon=%f";
+            "%sreverse?format=json&key=%s&accept-language=%s&lat=%f&lon=%f";
     private static final String SEARCH_GEOCODE_URL =
-            "%ssearch?format=json&accept-language=%s&addressdetails=1&bounded=1&q=%s&limit=%d";
+            "%ssearch?format=json&key=%s&accept-language=%s&addressdetails=1&bounded=1&q=%s&limit=%d";
     private static final String SEARCH_GEOCODE_WITH_BOX_URL =
-            "%ssearch?format=json&accept-language=%s&addressdetails=1&bounded=1&q=%s&limit=%d" +
+            "%ssearch?format=json&key=%s&accept-language=%s&addressdetails=1&bounded=1&q=%s&limit=%d" +
                     "&viewbox=%f,%f,%f,%f";
     private static final String WIRE_LATITUDE = "lat";
     private static final String WIRE_LONGITUDE = "lon";
@@ -51,8 +53,12 @@ public class BackendService extends GeocoderBackendService {
     @Override
     protected List<Address> getFromLocation(double latitude, double longitude, int maxResults,
             String locale) {
+
+        SharedPreferences SP = PreferenceManager.getDefaultSharedPreferences(getBaseContext());
+        String mapquestApiKey = SP.getString("api_preference", "NA");
+
         String url = String.format(Locale.US, REVERSE_GEOCODE_URL, SERVICE_URL_MAPQUEST,
-                locale.split("_")[0], latitude, longitude);
+                mapquestApiKey, locale.split("_")[0], latitude, longitude);
         try {
             JSONObject result = new JSONObject(new AsyncGetRequest(this,
                     url).asyncStart().retrieveString());
@@ -84,15 +90,19 @@ public class BackendService extends GeocoderBackendService {
     protected List<Address> getFromLocationName(String locationName, int maxResults,
             double lowerLeftLatitude, double lowerLeftLongitude, double upperRightLatitude,
             double upperRightLongitude, String locale) {
+
+        SharedPreferences SP = PreferenceManager.getDefaultSharedPreferences(getBaseContext());
+        String mapquestApiKey = SP.getString("api_preference", "NA");
+
         String query = Uri.encode(locationName);
         String url;
         if (lowerLeftLatitude == 0 && lowerLeftLongitude == 0 && upperRightLatitude == 0 &&
                 upperRightLongitude == 0) {
             url = String.format(Locale.US, SEARCH_GEOCODE_URL, SERVICE_URL_MAPQUEST,
-                    locale.split("_")[0], query, maxResults);
+                    mapquestApiKey, locale.split("_")[0], query, maxResults);
         } else {
             url = String.format(Locale.US, SEARCH_GEOCODE_WITH_BOX_URL, SERVICE_URL_MAPQUEST,
-                    locale.split("_")[0], query, maxResults, lowerLeftLongitude,
+                    mapquestApiKey, locale.split("_")[0], query, maxResults, lowerLeftLongitude,
                     upperRightLatitude, upperRightLongitude, lowerLeftLatitude);
         }
         try {

--- a/src/main/java/org/microg/nlp/backend/nominatim/SettingsActivity.java
+++ b/src/main/java/org/microg/nlp/backend/nominatim/SettingsActivity.java
@@ -1,18 +1,11 @@
 package org.microg.nlp.backend.nominatim;
 
-import android.app.FragmentManager;
-import android.app.FragmentTransaction;
 import android.content.SharedPreferences;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceFragment;
-import android.preference.PreferenceManager;
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
-
-import java.util.List;
-
 
 public class SettingsActivity extends PreferenceActivity {
     @Override

--- a/src/main/java/org/microg/nlp/backend/nominatim/SettingsActivity.java
+++ b/src/main/java/org/microg/nlp/backend/nominatim/SettingsActivity.java
@@ -1,0 +1,65 @@
+package org.microg.nlp.backend.nominatim;
+
+import android.app.FragmentManager;
+import android.app.FragmentTransaction;
+import android.content.SharedPreferences;
+import android.preference.ListPreference;
+import android.preference.Preference;
+import android.preference.PreferenceActivity;
+import android.preference.PreferenceFragment;
+import android.preference.PreferenceManager;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+
+import java.util.List;
+
+
+public class SettingsActivity extends PreferenceActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // Display the fragment as the main content.
+        getFragmentManager().beginTransaction()
+                .replace(android.R.id.content, new PrefsFragment()).commit();
+
+    }
+
+    public static class PrefsFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
+
+        @Override
+        public void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+
+            // Load the preferences from an XML resource
+            addPreferencesFromResource(R.xml.preferences);
+            setSummaries();
+            getPreferenceScreen().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
+        }
+
+        @Override
+        public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+            updatePreference(findPreference(key), key);
+        }
+
+        private void setSummaries(){
+
+            final SharedPreferences sh = getPreferenceManager().getSharedPreferences() ;
+
+            Preference stylePref = findPreference("api_preference");
+            stylePref.setSummary(sh.getString("api_preference", ""));
+
+        }
+        private void updatePreference(Preference preference, String key) {
+            if (preference == null) return;
+            if (preference instanceof ListPreference) {
+                ListPreference listPreference = (ListPreference) preference;
+                listPreference.setSummary(listPreference.getEntry());
+                return;
+            }
+            SharedPreferences sharedPrefs = getPreferenceManager().getSharedPreferences();
+            preference.setSummary(sharedPrefs.getString(key, "Default"));
+        }
+    }
+
+}

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">NominatimGeocoderBackend</string>
+    <string name="app_name">Nominatim Geocoder Backend</string>
     <string name="backend_name">Nominatim</string>
+
+    <string name="server_access">MapQuest Server Access</string>
+    <string name="api_title">MapQuest Developer API Key</string>
+    <string name="api_summary">MapQuest Developer API Key</string>
+    <string name="api_dialog_title">Enter your MapQuest developer API key.</string>
 </resources>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <PreferenceCategory
+        android:title="@string/server_access">
+
+        <EditTextPreference
+            android:key="api_preference"
+            android:title="@string/api_title"
+            android:summary=""
+            android:dialogTitle="@string/api_dialog_title"
+            android:defaultValue=""/>
+
+    </PreferenceCategory>
+
+</PreferenceScreen>


### PR DESCRIPTION
MapQuest requires a developer API key now and there is no reasonable way to provide a paid one with sufficient capacity to handle all the requests from Nominatim. So this patch provides a way for the end user to use their own developer API key which for low volume use they can get for free.

This is analogous to the situation that CyanogenMod is running into with their weather widget as discussed at http://www.cyanogenmod.org/blog/plug-play-weather and the solution has been to make plug-ins for possible service providers and have the plug-ins configurable by the user to use their own key.
