### PR TITLE
Use https

### DIFF
--- a/src/main/java/org/microg/nlp/backend/nominatim/BackendService.java
+++ b/src/main/java/org/microg/nlp/backend/nominatim/BackendService.java
@@ -15,13 +15,14 @@ import org.microg.nlp.api.GeocoderBackendService;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.net.ssl.HttpsURLConnection;
 
 public class BackendService extends GeocoderBackendService {
     private static final String TAG = "NominatimGeocoder";
@@ -184,7 +185,7 @@ public class BackendService extends GeocoderBackendService {
             synchronized (done) {
                 try {
                     Log.d(TAG, "Requesting " + url);
-                    HttpURLConnection connection = (HttpURLConnection) new URL(url)
+                    HttpsURLConnection connection = (HttpsURLConnection) new URL(url)
                             .openConnection();
                     setUserAgentOnConnection(connection);
                     connection.setDoInput(true);

--- a/src/main/java/org/microg/nlp/backend/nominatim/BackendService.java
+++ b/src/main/java/org/microg/nlp/backend/nominatim/BackendService.java
@@ -25,8 +25,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class BackendService extends GeocoderBackendService {
     private static final String TAG = "NominatimGeocoder";
-    private static final String SERVICE_URL_MAPQUEST = "http://open.mapquestapi.com/nominatim/v1/";
-    private static final String SERVICE_URL_OSM = " http://nominatim.openstreetmap.org/";
+
+    private static final String SERVICE_URL_MAPQUEST = "https://open.mapquestapi.com/nominatim/v1/";
+    private static final String SERVICE_URL_OSM = "https://nominatim.openstreetmap.org/";
 
     private static final String REVERSE_GEOCODE_URL =
             "%sreverse?format=json&accept-language=%s&lat=%f&lon=%f";

--- a/src/main/java/org/microg/nlp/backend/nominatim/BackendService.java
+++ b/src/main/java/org/microg/nlp/backend/nominatim/BackendService.java
@@ -24,9 +24,10 @@ import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class BackendService extends GeocoderBackendService {
-    private static final String TAG = "NominatimGeocoderBackend";
+    private static final String TAG = "NominatimGeocoder";
     private static final String SERVICE_URL_MAPQUEST = "http://open.mapquestapi.com/nominatim/v1/";
     private static final String SERVICE_URL_OSM = " http://nominatim.openstreetmap.org/";
+
     private static final String REVERSE_GEOCODE_URL =
             "%sreverse?format=json&accept-language=%s&lat=%f&lon=%f";
     private static final String SEARCH_GEOCODE_URL =


### PR DESCRIPTION
MapQuest and OSM APIs are accessible using HTTPS protocol.
Closes #8 .

Fix TAG string which can be at most 23 chars.

Note: Remember that you will still not be able to use Nominatim API if you do not have an API key. (See #4  )