### PR TITLE
Migrate to androidX for fixing compile issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
@@ -51,24 +52,27 @@ int getMyVersionCode() {
 }
 
 repositories {
+    google()
     jcenter()
 }
 
 dependencies {
-    compile 'org.microg:unifiednlp-api:1.5.6'
-    compile 'org.microg:address-formatter:0.2.1'
-    compile 'com.takisoft.fix:preference-v7:25.3.1.0'
+    implementation 'org.microg:unifiednlp-api:1.5.6'
+    implementation 'org.microg:address-formatter:0.2.1'
+    //noinspection GradleCompatible,GradleCompatible
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'com.takisoft.fix:preference-v7:25.3.1.0'
 }
 
-android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    android {
+    compileSdkVersion 29
+    buildToolsVersion "29.0.3"
 
     defaultConfig {
         versionName getMyVersionName()
         versionCode(20000 + getMyVersionCode())
-        minSdkVersion 9
-        targetSdkVersion 25
+        minSdkVersion 14
+        targetSdkVersion 29
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.enableJetifier=true
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Feb 12 23:24:00 UTC 2017
+#Sun Sep 06 12:08:56 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/src/main/java/org/microg/nlp/backend/nominatim/SettingsActivity.java
+++ b/src/main/java/org/microg/nlp/backend/nominatim/SettingsActivity.java
@@ -2,9 +2,9 @@ package org.microg.nlp.backend.nominatim;
 
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.preference.ListPreference;
-import android.support.v7.preference.Preference;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
 
 import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat;
 


### PR DESCRIPTION
Building this with build tools version 2.3.1 creates error messages because these build tools still specify a mips target, which does not exist anymore. Updating the build tools to a current versions forces us to update to AndroidX, which requires setting higher min and targetSdk versions.